### PR TITLE
Add basic auth and theme toggling

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 // app/dashboard/page.tsx
 "use client"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import AuthGuard from "@/components/AuthGuard"
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, LineChart, Line, PieChart, Pie, Cell, Legend } from "recharts"
 
 const data = [
@@ -22,8 +23,9 @@ const COLORS = ["#2563eb", "#4ade80", "#facc15"]
 
 export default function DashboardPage() {
   return (
-    <div className="space-y-6">
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+    <AuthGuard roles={["Admin", "Editor", "Viewer"]}>
+      <div className="space-y-6">
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         <Card>
           <CardHeader>
             <CardTitle>Users</CardTitle>
@@ -102,5 +104,6 @@ export default function DashboardPage() {
         </Card>
       </div>
     </div>
+    </AuthGuard>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,8 @@ import "@/app/globals.css"
 import { ReactNode } from "react"
 import { Sidebar } from "@/components/Sidebar"
 import { Topbar } from "@/components/Topbar"
+import { AuthProvider } from "@/context/AuthContext"
+import { UIProvider } from "@/context/UIContext"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,13 +27,17 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body
-        className={`flex h-screen overflow-hidden bg-white text-gray-900 ${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`flex h-screen overflow-hidden bg-white text-gray-900 dark:bg-gray-800 ${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Sidebar />
-        <div className="flex flex-col flex-1 overflow-hidden">
-          <Topbar />
-          <main className="flex-1 overflow-y-auto bg-gray-100 p-6">{children}</main>
-        </div>
+        <AuthProvider>
+          <UIProvider>
+            <Sidebar />
+            <div className="flex flex-col flex-1 overflow-hidden">
+              <Topbar />
+              <main className="flex-1 overflow-y-auto bg-gray-100 dark:bg-gray-700 p-6">{children}</main>
+            </div>
+          </UIProvider>
+        </AuthProvider>
       </body>
     </html>
   )

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,43 @@
+"use client"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@/context/AuthContext"
+import { useState } from "react"
+
+export default function LoginPage() {
+  const { user, login } = useAuth()
+  const router = useRouter()
+  const [name, setName] = useState("")
+  const [role, setRole] = useState("Viewer")
+
+  if (user) {
+    router.replace("/dashboard")
+    return null
+  }
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    login(name || "User", role)
+    router.replace("/dashboard")
+  }
+
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <form onSubmit={onSubmit} className="space-y-4 bg-white p-6 rounded shadow">
+        <h2 className="text-lg font-semibold">Login</h2>
+        <div>
+          <label className="block text-sm">Name</label>
+          <input className="border px-2 py-1 w-full" value={name} onChange={(e) => setName(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm">Role</label>
+          <select className="border px-2 py-1 w-full" value={role} onChange={(e) => setRole(e.target.value)}>
+            <option>Admin</option>
+            <option>Editor</option>
+            <option>Viewer</option>
+          </select>
+        </div>
+        <button type="submit" className="bg-blue-600 text-white px-3 py-1 rounded">Login</button>
+      </form>
+    </div>
+  )
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,4 +1,11 @@
 // app/settings/page.tsx
+"use client"
+import AuthGuard from "@/components/AuthGuard"
+
 export default function SettingsPage() {
-  return <h2 className="text-xl font-semibold">Settings</h2>
+  return (
+    <AuthGuard roles={["Admin"]}>
+      <h2 className="text-xl font-semibold">Settings</h2>
+    </AuthGuard>
+  )
 }

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,5 +1,6 @@
 // app/users/page.tsx
 "use client"
+import AuthGuard from "@/components/AuthGuard"
 
 const users = [
   { id: 1, name: "Alice Johnson", email: "alice@example.com", role: "Admin" },
@@ -9,6 +10,7 @@ const users = [
 
 export default function UsersPage() {
   return (
+    <AuthGuard roles={["Admin", "Editor"]}>
     <div>
       <h2 className="text-xl font-semibold mb-4">Users Management</h2>
       <div className="overflow-x-auto">
@@ -34,5 +36,6 @@ export default function UsersPage() {
         </table>
       </div>
     </div>
+    </AuthGuard>
   )
 }

--- a/components/AuthGuard.tsx
+++ b/components/AuthGuard.tsx
@@ -1,0 +1,24 @@
+"use client"
+import { useAuth } from "@/context/AuthContext"
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
+
+type Props = {
+  children: React.ReactNode
+  roles?: string[]
+}
+
+export default function AuthGuard({ children, roles }: Props) {
+  const { user } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!user) router.replace("/login")
+    else if (roles && !roles.includes(user.role)) router.replace("/login")
+  }, [user, router, roles])
+
+  if (!user) return null
+  if (roles && !roles.includes(user.role)) return null
+
+  return <>{children}</>
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,8 +1,8 @@
-// components/Sidebar.tsx
 "use client"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { LayoutDashboard, Users, Settings } from "lucide-react"
+import { useUI } from "@/context/UIContext"
 
 const navItems = [
   { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
@@ -12,20 +12,21 @@ const navItems = [
 
 export function Sidebar() {
   const pathname = usePathname()
+  const { sidebarCollapsed } = useUI()
   return (
-    <aside className="w-64 bg-white border-r p-4 hidden md:block">
-      <h2 className="text-2xl font-bold mb-6">Admin Dashboard</h2>
+    <aside className={`${sidebarCollapsed ? "w-16" : "w-64"} bg-white dark:bg-gray-900 border-r p-4 hidden md:block`}>
+      <h2 className="text-2xl font-bold mb-6">{!sidebarCollapsed && "Admin Dashboard"}</h2>
       <nav className="space-y-2">
         {navItems.map(({ name, href, icon: Icon }) => (
           <Link
             key={href}
             href={href}
-            className={`flex items-center gap-3 p-2 rounded-md hover:bg-gray-100 transition ${
-              pathname === href ? "bg-gray-200 font-medium" : ""
+            className={`flex items-center gap-3 p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition ${
+              pathname === href ? "bg-gray-200 dark:bg-gray-700 font-medium" : ""
             }`}
           >
             <Icon className="h-5 w-5" />
-            {name}
+            {!sidebarCollapsed && name}
           </Link>
         ))}
       </nav>

--- a/components/Topbar.tsx
+++ b/components/Topbar.tsx
@@ -1,14 +1,22 @@
-// components/Topbar.tsx
 "use client"
-import { CircleUser } from "lucide-react"
+import { CircleUser, Menu, Sun, Moon, LogOut } from "lucide-react"
+import { useUI } from "@/context/UIContext"
+import { useAuth } from "@/context/AuthContext"
 
 export function Topbar() {
+  const { toggleTheme, dark, toggleSidebar } = useUI()
+  const { user, logout } = useAuth()
   return (
-    <header className="h-16 border-b px-6 flex items-center justify-between bg-white">
-      <h1 className="text-lg font-semibold">Dashboard Admin</h1>
+    <header className="h-16 border-b px-6 flex items-center justify-between bg-white dark:bg-gray-800">
       <div className="flex items-center gap-3">
+        <button onClick={toggleSidebar} className="md:hidden"> <Menu className="w-6 h-6" /> </button>
+        <h1 className="text-lg font-semibold">Dashboard Admin</h1>
+      </div>
+      <div className="flex items-center gap-4">
+        <button onClick={toggleTheme}>{dark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}</button>
         <CircleUser className="w-6 h-6" />
-        <span className="text-sm">Admin User</span>
+        <span className="text-sm">{user?.name}</span>
+        <button onClick={logout}><LogOut className="w-5 h-5" /></button>
       </div>
     </header>
   )

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1,0 +1,47 @@
+"use client"
+import { createContext, useContext, useState, useEffect, ReactNode } from "react"
+
+type User = {
+  name: string
+  role: string
+}
+
+type AuthContextValue = {
+  user: User | null
+  login: (name: string, role: string) => void
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+
+  useEffect(() => {
+    const stored = localStorage.getItem("auth_user")
+    if (stored) setUser(JSON.parse(stored))
+  }, [])
+
+  const login = (name: string, role: string) => {
+    const u = { name, role }
+    setUser(u)
+    localStorage.setItem("auth_user", JSON.stringify(u))
+  }
+
+  const logout = () => {
+    setUser(null)
+    localStorage.removeItem("auth_user")
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider")
+  return ctx
+}

--- a/context/UIContext.tsx
+++ b/context/UIContext.tsx
@@ -1,0 +1,41 @@
+"use client"
+import { createContext, useContext, useState, useEffect, ReactNode } from "react"
+
+type UIContextValue = {
+  dark: boolean
+  sidebarCollapsed: boolean
+  toggleTheme: () => void
+  toggleSidebar: () => void
+}
+
+const UIContext = createContext<UIContextValue | undefined>(undefined)
+
+export function UIProvider({ children }: { children: ReactNode }) {
+  const [dark, setDark] = useState(false)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+
+  useEffect(() => {
+    const storedTheme = localStorage.getItem("theme")
+    if (storedTheme) setDark(storedTheme === "dark")
+  }, [])
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", dark)
+    localStorage.setItem("theme", dark ? "dark" : "light")
+  }, [dark])
+
+  const toggleTheme = () => setDark((d) => !d)
+  const toggleSidebar = () => setSidebarCollapsed((s) => !s)
+
+  return (
+    <UIContext.Provider value={{ dark, sidebarCollapsed, toggleTheme, toggleSidebar }}>
+      {children}
+    </UIContext.Provider>
+  )
+}
+
+export function useUI() {
+  const ctx = useContext(UIContext)
+  if (!ctx) throw new Error("useUI must be used within UIProvider")
+  return ctx
+}


### PR DESCRIPTION
## Summary
- implement a lightweight authentication context
- create UI state context for theme and sidebar
- add login page and guard admin routes
- update sidebar and topbar to support collapsing and dark mode

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a6e2ca9d083208faa982e301026c4